### PR TITLE
Use `require` to load `imandra-ptime`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,5 @@ FROM imandra/imandra-client-switch as fix-engine-build
 COPY --chown=opam:nogroup ./fix-engine.opam .
 RUN opam install . --deps-only --with-test --working-dir -y
 COPY --chown=opam:nogroup . .
+RUN make imandra-libs-install
 RUN make build build_tests run_parser_tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM imandra/imandra-client-switch as fix-engine-build
 
 COPY --chown=opam:nogroup ./fix-engine.opam .
+RUN opam pin -y -n imandra-prelude vendor/imandra-prelude
+RUN opam pin -y -n imandra-ptime vendor/imandra-ptime
 RUN opam install . --deps-only --with-test --working-dir -y
 COPY --chown=opam:nogroup . .
 RUN make imandra-libs-install

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ COPY --chown=opam:nogroup ./fix-engine.opam .
 COPY --chown=opam:nogroup ./vendor/imandra-ptime/imandra-ptime.opam .
 COPY --chown=opam:nogroup ./vendor/imandra-prelude/imandra-prelude.opam .
 RUN opam install . --deps-only --with-test --working-dir -y
+RUN rm imandra-ptime.opam imandra-prelude.opam
 COPY --chown=opam:nogroup . .
 RUN make imandra-libs-install
 RUN make build build_tests run_parser_tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 FROM imandra/imandra-client-switch as fix-engine-build
 
 COPY --chown=opam:nogroup ./fix-engine.opam .
-COPY --chown=opam:nogroup ./vendor/imandra-ptime/imandra-ptime.opam .
-COPY --chown=opam:nogroup ./vendor/imandra-prelude/imandra-prelude.opam .
-RUN opam install . --deps-only --with-test --working-dir -y
-RUN rm imandra-ptime.opam imandra-prelude.opam
+COPY --chown=opam:nogroup ./vendor/imandra-ptime/imandra-ptime.opam ./vendor/imandra-ptime/imandra-ptime.opam
+COPY --chown=opam:nogroup ./vendor/imandra-prelude/imandra-prelude.opam ./vendor/imandra-prelude/imandra-prelude.opam
+COPY --chown=opam:nogroup ./Makefile ./Makefile
+RUN make opam1-setup 
 COPY --chown=opam:nogroup . .
 RUN make imandra-libs-install
 RUN make build build_tests run_parser_tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM imandra/imandra-client-switch as fix-engine-build
 
 COPY --chown=opam:nogroup ./fix-engine.opam .
-RUN opam pin -y -n imandra-prelude vendor/imandra-prelude
-RUN opam pin -y -n imandra-ptime vendor/imandra-ptime
+COPY --chown=opam:nogroup ./vendor/imandra-ptime/imandra-ptime.opam .
+COPY --chown=opam:nogroup ./vendor/imandra-prelude/imandra-prelude.opam .
 RUN opam install . --deps-only --with-test --working-dir -y
 COPY --chown=opam:nogroup . .
 RUN make imandra-libs-install

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ opam2-setup: _opam opam1-setup
 
 _opam:
 	opam switch create . --empty
-	opam install -y ocaml-base-compiler.4.12.1
+	opam switch set-invariant ocaml-base-compiler.4.12.1
 
 format:
 	@echo "(dirs :standard \ *-vg)" > dune

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,16 @@
 # Makefile
 
 DUNE_OPTS?= --profile=release
+IMANDRA_SWITCH?=/usr/local/var/imandra
+
+imandra-libs-install:
+	cd vendor/imandra-ptime && opam install . --switch $(IMANDRA_SWITCH) -y && cd -
+
+imandra-libs-uninstall:
+	opam uninstall imandra-ptime --switch $(IMANDRA_SWITCH)
+
+imandra-libs-unpin:
+	opam unpin imandra-ptime --switch $(IMANDRA_SWITCH)
 
 build:
 	opam exec -- dune build $(DUNE_OPTS) @install

--- a/Makefile
+++ b/Makefile
@@ -36,16 +36,20 @@ module_graph.svg: _build/doc/all_modules.docdir/all_modules.dot
 
 # opam1-setup - for running in Wercker. Assumes the correct switch is already installed and selected.
 opam1-setup:
-	opam pin add -y . --no-action
-	opam depext -y fix-engine
-	opam install fix-engine --deps-only
+	opam install \
+	  ./vendor/imandra-ptime/imandra-ptime.opam \
+	  ./vendor/imandra-prelude/imandra-prelude.opam \
+	  ./fix-engine.opam \
+	  --deps-only -y
 
+# Note: keep this opam install command in sync with the Dockerfile
 # opam2-setup - Will create a local switch under ./_opam.
 opam2-setup: _opam
-	opam pin -y -n imandra-prelude vendor/imandra-prelude
-	opam pin -y -n imandra-ptime vendor/imandra-ptime
-	opam pin add -y . --no-action
-	opam install -y . --deps-only --with-test --working-dir
+	opam install \
+	  ./vendor/imandra-ptime/imandra-ptime.opam \
+	  ./vendor/imandra-prelude/imandra-prelude.opam \
+	  ./fix-engine.opam \
+	  --deps-only -y
 
 _opam:
 	opam switch create . --empty

--- a/Makefile
+++ b/Makefile
@@ -43,12 +43,13 @@ opam1-setup:
 # opam2-setup - Will create a local switch under ./_opam.
 opam2-setup: _opam
 	opam pin add -y . --no-action
-	opam depext -y fix-engine
+	opam pin -y -n imandra-prelude vendor/imandra-prelude
+	opam pin -y -n imandra-ptime vendor/imandra-ptime
 	opam install -y . --deps-only --with-test --working-dir
 
 _opam:
 	opam switch create . --empty
-	opam install -y ocaml-base-compiler.4.05.0
+	opam install -y ocaml-base-compiler.4.12.1
 
 format:
 	@echo "(dirs :standard \ *-vg)" > dune

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ doc:
 module_graph.svg: _build/doc/all_modules.docdir/all_modules.dot
 	sed -e 's/rotate=90;//g' "$<" | dot -Tsvg -o $@
 
+# Note: keep this opam install command in sync with the Dockerfile
 # opam1-setup - for running in Wercker. Assumes the correct switch is already installed and selected.
 opam1-setup:
 	opam install \
@@ -42,14 +43,8 @@ opam1-setup:
 	  ./fix-engine.opam \
 	  --deps-only -y
 
-# Note: keep this opam install command in sync with the Dockerfile
 # opam2-setup - Will create a local switch under ./_opam.
-opam2-setup: _opam
-	opam install \
-	  ./vendor/imandra-ptime/imandra-ptime.opam \
-	  ./vendor/imandra-prelude/imandra-prelude.opam \
-	  ./fix-engine.opam \
-	  --deps-only -y
+opam2-setup: _opam opam1-setup
 
 _opam:
 	opam switch create . --empty

--- a/Makefile
+++ b/Makefile
@@ -42,9 +42,9 @@ opam1-setup:
 
 # opam2-setup - Will create a local switch under ./_opam.
 opam2-setup: _opam
-	opam pin add -y . --no-action
 	opam pin -y -n imandra-prelude vendor/imandra-prelude
 	opam pin -y -n imandra-ptime vendor/imandra-ptime
+	opam pin add -y . --no-action
 	opam install -y . --deps-only --with-test --working-dir
 
 _opam:

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -14,3 +14,6 @@ steps:
       - '-c'
       - |
         docker build -t fix-engine-build . --target fix-engine-build
+
+options:
+  machineType: 'N1_HIGHCPU_8'

--- a/fix-engine.opam
+++ b/fix-engine.opam
@@ -20,6 +20,7 @@ depends: [
   "zmq-lwt"
   "logs"
   "ppx_deriving"
+  "imandra-ptime"
   "ocaml" {>= "4.08.0"}
   "benchmark" {with-test}
   "qcheck-core" {with-test}

--- a/fix-engine/src-core/datetime.iml
+++ b/fix-engine/src-core/datetime.iml
@@ -10,7 +10,7 @@
 
 [@@@require "imandra-ptime"]
 
-[@@@require "imandra-ptime-extra"]
+[@@@require "imandra-ptime.extra"]
 
 [@@@import "./ints.iml"]
 

--- a/fix-engine/src-core/datetime.iml
+++ b/fix-engine/src-core/datetime.iml
@@ -8,9 +8,9 @@
     datetime.iml
 *)
 
-[@@@import "../../vendor/imandra-ptime/src/imandra_ptime.iml"]
+[@@@require "imandra-ptime"]
 
-[@@@import "../../vendor/imandra-ptime/src-extra/imandra_ptime_extra.iml"]
+[@@@require "imandra-ptime-extra"]
 
 [@@@import "./ints.iml"]
 


### PR DESCRIPTION
`imandra-ptime` is installed into the imandra switch, allowing loading with `require`. Closes #187.