### PR TITLE
Improve scrutability of engine state transitions

### DIFF
--- a/fix-engine/src-protocol-pp/fix_engine_json.iml
+++ b/fix-engine/src-protocol-pp/fix_engine_json.iml
@@ -36,6 +36,11 @@ let fix_engine_mode_to_string = function
     | WaitingForHeartbeat                               -> "WaitingForHeartbeat"
 ;;
 
+let fix_engine_transition_message_to_string = function
+    | ShuttingDown msg      -> "ShuttingDown: " ^ msg
+    | LogonFailed msg       -> "LogonFailed: " ^ msg
+    | LogonSucceeded msg    -> "LogonSucceeded: " ^ msg
+
 let manual_int_data_to_json x : Yojson.Basic.t = match x with
     | ResetSession    -> `String "ResetSession"
     | IncrementOutSeq -> `String "IncrementOutSeq"

--- a/fix-engine/src-protocol-pp/fix_engine_json.iml
+++ b/fix-engine/src-protocol-pp/fix_engine_json.iml
@@ -10,6 +10,7 @@
 [@@@import "../src/fix_engine_state.iml"]
 [@@@import "../src-core-pp/datetime_json.iml"]
 [@@@import "../src-core-pp/base_types_json.iml"]
+[@@@import "full_admin_tags_json.iml"]
 [@@@import "full_messages_json.iml"]
 
 [@@@program]
@@ -17,6 +18,7 @@ open Yojson.Basic
 open Fix_engine_state
 open Datetime_json
 open Base_types_json
+open Full_admin_tags_json
 open Full_admin_messages_json
 open Full_messages_json
 
@@ -37,9 +39,21 @@ let fix_engine_mode_to_string = function
 ;;
 
 let fix_engine_transition_message_to_string = function
-    | ShuttingDown msg      -> "ShuttingDown: " ^ msg
-    | LogonFailed msg       -> "LogonFailed: " ^ msg
-    | LogonSucceeded msg    -> "LogonSucceeded: " ^ msg
+    | ShuttingDown msg                                  -> "ShuttingDown: " ^ msg
+    | LogonFailed msg                                   -> "LogonFailed: " ^ msg
+    | LogonSucceeded msg                                -> "LogonSucceeded: " ^ msg
+    | MissingField tag                                  -> "MissingField: " ^ (full_admin_field_tag_to_string tag)
+    | SequenceNumberReset num                           -> "SequenceNumberReset: to " ^ (Int.to_string num)
+    | LogoutTimeout                                     -> "LogoutTimeout"
+    | LogoutComplete                                    -> "LogoutComplete"
+    | GapDetected                                       -> "GapDetected"
+    | ValidDuplicateIgnored                             -> "ValidDuplicateIgnored"
+    | TestRequestReceived msg                           -> "TestRequestReceived: " ^ msg
+    | TestRequestSent msg                               -> "TestRequestSent: " ^ msg
+    | TestRequestTimeout                                -> "TestRequestTimeout"
+    | TestRequestAcknowledged                           -> "TestRequestAcknowledged"
+    | MessageIgnored msg                                -> "MessageIgnored: " ^ msg
+    | TerminateTransport msg                            -> "TerminateTransport: " ^ msg 
 
 let manual_int_data_to_json x : Yojson.Basic.t = match x with
     | ResetSession    -> `String "ResetSession"

--- a/fix-engine/src-runtime/runtime.ml
+++ b/fix-engine/src-runtime/runtime.ml
@@ -1,5 +1,7 @@
 let ( let* ) = Lwt.bind
 
+let ( let+ ) = Lwt.( >|= )
+
 type direction =
   | Incoming
   | Outgoing
@@ -19,9 +21,11 @@ type message = {
 
 type transition_message = Fix_engine_state.transition_message
 
+let show_transition_message =
+  Fix_engine_json.fix_engine_transition_message_to_string
+
 let pp_transition_message fmt msg =
-  CCFormat.fprintf fmt "%s"
-    (Fix_engine_json.fix_engine_transition_message_to_string msg)
+  CCFormat.fprintf fmt "%s" (show_transition_message msg)
 
 type event =
   | Log of string
@@ -58,19 +62,31 @@ let mk_event message direction =
   FIXMessage { message; direction; msg_type }
 
 let receive_fix_io t message =
-  Lwt.join
-    [
-      Engine.process_fix_wire t.engine message;
-      t.recv (mk_event message Incoming);
-    ]
+  let+ () =
+    Lwt.join
+      [
+        Engine.process_fix_wire t.engine message;
+        t.recv (mk_event message Incoming);
+      ]
+  in
+  false
 
 let receive_engine t event =
   match event, t.fixio with
   | Engine.FIXFromEngine message, Some fixio ->
-    Lwt.join [ Fix_io.send fixio message; t.recv (mk_event message Outgoing) ]
-  | Engine.Log msg, _ -> t.recv (Log msg)
-  | Engine.TransitionMessage msg, _ -> t.recv (TransitionMessage msg)
-  | _ -> Lwt.return_unit
+    let+ () =
+      Lwt.join [ Fix_io.send fixio message; t.recv (mk_event message Outgoing) ]
+    in
+    false
+  | Engine.Log msg, _ ->
+    let+ () = t.recv (Log msg) in
+    false
+  | Engine.TransitionMessage msg, _ ->
+    let+ () = t.recv (TransitionMessage msg) in
+    (match msg with
+    | TerminateTransport _ -> true
+    | _ -> false)
+  | _ -> Lwt.return_false
 
 let on_disconnect t addr_str =
   let* () =
@@ -80,23 +96,24 @@ let on_disconnect t addr_str =
 
 let receive_send t message =
   let* result = Engine.send_fix_message t.engine message in
-  Lwt_mvar.put t.result_box result
+  let+ () = Lwt_mvar.put t.result_box result in
+  false
 
-let rec loop (t : t) : unit Lwt.t =
+let rec engine_io_thread (t : t) : unit Lwt.t =
   let rec loop_box box receiver =
     let* msg = Lwt_mvar.take box in
-    let* () = receiver t msg in
-    loop_box box receiver
+    let* terminate = receiver t msg in
+    if terminate then
+      Lwt.return_unit
+    else
+      loop_box box receiver
   in
-  let* () =
-    Lwt.join
-      [
-        loop_box t.engine_box receive_engine;
-        loop_box t.fixio_box receive_fix_io;
-        loop_box t.send_box receive_send;
-      ]
-  in
-  loop t
+  Lwt.pick
+    [
+      loop_box t.engine_box receive_engine;
+      loop_box t.fixio_box receive_fix_io;
+      loop_box t.send_box receive_send;
+    ]
 
 let with_catch_disconnect t f =
   Lwt.catch f (fun e ->
@@ -127,7 +144,7 @@ let server_handler (t : t) (in_addr : Unix.sockaddr) (inch, outch) =
     let fixio_thread, fixio = Fix_io.start ~recv ?log_file (inch, outch) in
     let t = { t with fixio = Some fixio } in
     Lwt.finalize
-      (fun () -> Lwt.pick [ fixio_thread; loop t ])
+      (fun () -> Lwt.pick [ fixio_thread; engine_io_thread t ])
       (fun _ -> on_disconnect t addr_str)
 
 let default_session_folder ~(config : Engine.config) =
@@ -201,7 +218,7 @@ let client_handler addr_str (t, engine_thread, init_msg) (inch, outch) =
   in
   let t = { t with fixio = Some fixio } in
   let* () = Engine.send_internal_message t.engine init_msg in
-  Lwt.pick [ engine_thread; fixio_thread; loop t ]
+  Lwt.pick [ engine_thread; fixio_thread; engine_io_thread t ]
 
 let start_client ?(session_dir : string option) ?(log_file : string option)
     ?(reset : bool option) ~(config : Engine.config) ~(host : string)

--- a/fix-engine/src-runtime/runtime.mli
+++ b/fix-engine/src-runtime/runtime.mli
@@ -21,6 +21,7 @@ type event =
   | Connected of string
   | Disconnected of string
   | ConnectionRejected of string
+  | TransitionMessage of Fix_engine_state.transition_message
 [@@deriving show]
 
 type handle

--- a/fix-engine/src-runtime/runtime.mli
+++ b/fix-engine/src-runtime/runtime.mli
@@ -15,13 +15,15 @@ type message = {
 }
 [@@deriving show]
 
+type transition_message = Fix_engine_state.transition_message [@@deriving show]
+
 type event =
   | Log of string
   | FIXMessage of message
   | Connected of string
   | Disconnected of string
   | ConnectionRejected of string
-  | TransitionMessage of Fix_engine_state.transition_message
+  | TransitionMessage of transition_message
 [@@deriving show]
 
 type handle

--- a/fix-engine/src/fix_engine.iml
+++ b/fix-engine/src/fix_engine.iml
@@ -253,7 +253,7 @@ let one_step ( engine : fix_engine_state ) =
     (* If we still need to retransmit our messages out to the receiving engine. *)
     | Retransmit   -> run_retransmit (engine)
     (* We need to send out Logoff and transition to ShutdownInitiated *)
-    | ShuttingDown -> logoff_and_shutdown (engine)
+    | ShuttingDown -> logoff_and_shutdown ("In ShuttingDown mode", engine)
     (* Now we look to process internal (coming from our application) and external (coming from
         another FIX engine) messages. *)
     | _ -> begin match engine.incoming_fix_msg with 

--- a/fix-engine/src/fix_engine.iml
+++ b/fix-engine/src/fix_engine.iml
@@ -43,6 +43,7 @@ let proc_incoming_int_msg ( x, engine : fix_engine_int_inc_msg * fix_engine_stat
                                 fe_last_time_data_sent  = engine'.fe_curr_time;
                                 fe_history              = add_msg_to_history ( engine'.fe_history, test_request_msg );
                         }
+                        |> with_transition_message (TestRequestSent engine.last_test_req_id)
                     end 
                 else
 
@@ -78,8 +79,27 @@ let proc_incoming_int_msg ( x, engine : fix_engine_int_inc_msg * fix_engine_stat
                                 outgoing_seq_num        = engine'.outgoing_seq_num + 1;
                                 fe_last_time_data_sent  = engine'.fe_curr_time;
                                 fe_history              = add_msg_to_history ( engine.fe_history, logoff_msg );
-                        }
+                        } 
+                        |> with_transition_message TestRequestTimeout 
+                        |> with_transition_message (TerminateTransport "No timely response to TestRequest")
                     end
+                else
+                    engine'
+            end
+        else if engine.fe_curr_mode = ShutdownInitiated then
+            begin
+            (* Wait twice the heartbeat_interval, as recommended in the FIX Session Layer specification *)
+                let received_cutoff = engine.fe_last_time_data_sent 
+                    |> utctimestamp_micro_duration_Add engine.fe_heartbeat_interval
+                    |> utctimestamp_micro_duration_Add engine.fe_heartbeat_interval in
+                if utctimestamp_GreaterThan_micro_micro t received_cutoff then
+                    { 
+                        engine' with
+                            fe_curr_mode            = NoActiveSession;
+                            fe_curr_status          = ConnTerminatedWithoutLogoff;
+                    } 
+                    |> with_transition_message LogoutTimeout 
+                    |> with_transition_message (TerminateTransport "No timely response to Logout message, shutting down")
                 else
                     engine'
             end

--- a/fix-engine/src/fix_engine_state.iml
+++ b/fix-engine/src/fix_engine_state.iml
@@ -12,11 +12,13 @@
 open Datetime
 
 [@@@import "../src-protocol/full_admin_enums.iml"]
+[@@@import "../src-protocol/full_admin_tags.iml"]
 
 [@@@import "../src-protocol/full_messages.iml"]
 
 open Full_admin_enums
 open Full_admin_messages
+open Full_admin_tags
 open Full_messages
 
 (** Define set of actions + data for manual intervention by the user. *)
@@ -87,6 +89,18 @@ type transition_message =
   | ShuttingDown of string
   | LogonFailed of string
   | LogonSucceeded of string
+  | MissingField of full_admin_field_tag
+  | SequenceNumberReset of int
+  | LogoutTimeout
+  | LogoutComplete
+  | GapDetected
+  | ValidDuplicateIgnored
+  | TestRequestReceived of string
+  | TestRequestSent of string
+  | TestRequestAcknowledged
+  | TestRequestTimeout
+  | MessageIgnored of string
+  | TerminateTransport of string
 
 type fix_engine_state = {
   fe_begin_string: string;
@@ -145,7 +159,7 @@ type fix_engine_state = {
   fe_encrypt_method: fix_encryption_method;
   logon_extra_fields: (string * string) list;
   fe_next_expected_msg_seq_num: int option;
-  transition_log: transition_message option;
+  transition_log: transition_message list;
 }
 (** Engine state structure containing all of the information required for it operate. *)
 
@@ -186,7 +200,7 @@ let init_fix_engine_state =
     fe_encrypt_method = NoEncryption;
     logon_extra_fields = [];
     fe_next_expected_msg_seq_num = None;
-    transition_log = None;
+    transition_log = [];
   }
 
 (** THEOREM: one_step calls on busy state eventually terminate *)

--- a/fix-engine/src/fix_engine_state.iml
+++ b/fix-engine/src/fix_engine_state.iml
@@ -83,6 +83,11 @@ type cache_entry =
   | CacheMessage of full_valid_fix_msg
   | CacheGap of int * int
 
+type transition_message =
+  | ShuttingDown of string
+  | LogonFailed of string
+  | LogonSucceeded of string
+
 type fix_engine_state = {
   fe_begin_string: string;
   fe_curr_status: fix_engine_status;  (** Status. *)
@@ -140,6 +145,7 @@ type fix_engine_state = {
   fe_encrypt_method: fix_encryption_method;
   logon_extra_fields: (string * string) list;
   fe_next_expected_msg_seq_num: int option;
+  transition_log: transition_message option;
 }
 (** Engine state structure containing all of the information required for it operate. *)
 
@@ -180,6 +186,7 @@ let init_fix_engine_state =
     fe_encrypt_method = NoEncryption;
     logon_extra_fields = [];
     fe_next_expected_msg_seq_num = None;
+    transition_log = None;
   }
 
 (** THEOREM: one_step calls on busy state eventually terminate *)

--- a/fix-engine/src/fix_engine_transitions.iml
+++ b/fix-engine/src/fix_engine_transitions.iml
@@ -34,8 +34,7 @@ let logoff_and_shutdown ( reason, engine : string * fix_engine_state ) =
         outgoing_fix_msg        = Some ( ValidMsg ( logoff_msg ));
         outgoing_seq_num        = engine.outgoing_seq_num + 1;
         fe_history              = add_msg_to_history ( engine.fe_history, logoff_msg );
-        transition_log          = Some (ShuttingDown reason)
-    }
+    } |> with_transition_message (ShuttingDown reason)
 ;;
 
 (** Before sending out a historic message, we need to:
@@ -107,11 +106,15 @@ let run_no_active_session ( m, engine : full_valid_fix_msg * fix_engine_state ) 
     | Full_FIX_Admin_Msg ( Full_Msg_Logon d ) ->
         begin
             if ( m.full_msg_header.h_target_comp_id <> engine.fe_comp_id ) then
-                { engine with transition_log = Some (LogonFailed "Invalid TargetCompID") }
+                engine 
+                |> with_transition_message ( LogonFailed "Invalid TargetCompID" )
+                |> with_transition_message ( TerminateTransport "Logon failed due to invalid TargetCompID" )
             else if
                ( m.full_msg_header.h_sender_comp_id <> engine.fe_target_comp_id )
                then
-                { engine with transition_log = Some (LogonFailed "Invalid SenderCompID") }
+               engine 
+               |> with_transition_message ( LogonFailed "Invalid SenderCompID" )
+               |> with_transition_message ( TerminateTransport "Logon failed due to invalid SenderCompID" )
             else if
               (* TODO: better timestamp comparison *)
               let sending_day, _ps = m.full_msg_header.h_sending_time |> T.to_span |> T.Span.to_d_ps in
@@ -124,8 +127,8 @@ let run_no_active_session ( m, engine : full_valid_fix_msg * fix_engine_state ) 
                     engine with
                         fe_curr_mode = Error;
                         fe_curr_status = MaxNumLogonMsgsViolated;
-                        transition_log = Some (LogonFailed "Maximum number of logon attempts exceeded")
-            } else
+                } |> with_transition_message (LogonFailed "Maximum number of logon attempts exceeded" )
+            else
                 begin
                     let engine = match d.ln_reset_seq_num_flag with
                         | Some true -> { engine with incoming_seq_num = 0; outgoing_seq_num = 0 }
@@ -151,14 +154,13 @@ let run_no_active_session ( m, engine : full_valid_fix_msg * fix_engine_state ) 
                     then { engine with
                         incoming_seq_num  = engine.incoming_seq_num + 1;
                         fe_curr_mode      = GapDetected;
-                        transition_log    = Some (LogonSucceeded "Gap detected")
-                    } else
+                    } |> with_transition_message ( LogonSucceeded "Gap detected during acceptor logon" )
+                    else
                     { engine with
                         fe_curr_mode      = ActiveSession;
                         incoming_seq_num  = m.full_msg_header.h_msg_seq_num;
                         fe_history        = add_msg_to_history ( engine.fe_history, logon_msg );
-                        transition_log    = Some (LogonSucceeded "Session active")
-                    }
+                    } |> with_transition_message ( LogonSucceeded "Session active after acceptor logon" )
                 end
         end
     | _ -> engine
@@ -186,13 +188,13 @@ let run_logon_sequence ( m, engine : full_valid_fix_msg * fix_engine_state ) =
                                 fe_last_time_data_sent  = engine.fe_curr_time;
                                 fe_num_logons_sent      = engine.fe_num_logons_sent + 1;
                                 fe_history              = add_msg_to_history ( engine.fe_history, logon_msg );
-                        }
+                        } |> with_transition_message ( LogonFailed "Mismatched encryption during initiator logon, resending Logon message" )
                     end
                 else {
                     engine' with
                         fe_curr_mode = ActiveSession;
                         incoming_seq_num = m.full_msg_header.h_msg_seq_num;
-                }
+                } |> with_transition_message ( LogonSucceeded "Session active after initiator logon" )
             end
         | _ -> engine'
 ;;
@@ -236,8 +238,9 @@ let attempt_sequence_reset (engine, msg_seq_num, new_seq_num : fix_engine_state 
             Most logical thing seems to just not change it at all*)
         { engine' with incoming_seq_num = engine.incoming_seq_num }
     else {
-        engine with incoming_seq_num = new_seq_num - 1
-    }
+        engine with 
+            incoming_seq_num = new_seq_num - 1;
+    } |> with_transition_message ( SequenceNumberReset new_seq_num )
 ;;
 
 (** We're operating in a normal mode. *)
@@ -261,7 +264,7 @@ let run_active_session ( m, engine : full_valid_fix_msg * fix_engine_state ) =
                 outgoing_seq_num        = engine.outgoing_seq_num + 1;
                 fe_last_time_data_sent  = engine.fe_curr_time;
                 fe_history              = add_msg_to_history ( engine.fe_history, logon_msg );
-            }
+            } |> with_transition_message ( SequenceNumberReset 1 )
         | _ -> engine
         )
     | _ ->  
@@ -273,10 +276,10 @@ let run_active_session ( m, engine : full_valid_fix_msg * fix_engine_state ) =
     let possdup = match header.h_poss_dup_flag with Some true -> true | _ -> false in
     if is_duplicate && not possdup then
         (* Message is a duplicate, but no PossibleDuplicate flag -- we instantly logoff *)
-        logoff_and_shutdown ("Duplicate message received without PossibleDuplicate flag", engine)
+        logoff_and_shutdown ("Message with sequence number below watermark received without PossibleDuplicate flag", engine)
     else if is_duplicate then
         (* Message is a duplicate and passed all checks -- ignore it. *)
-        engine
+        engine |> with_transition_message ValidDuplicateIgnored
     else if msg_is_sequence_gap ( engine, m.full_msg_header ) then {
         (* We've detected a gap in messages. We therefore need to
             transition into GapDetected mode. We place the message into the cahce. *)
@@ -284,7 +287,8 @@ let run_active_session ( m, engine : full_valid_fix_msg * fix_engine_state ) =
             fe_curr_mode = GapDetected;
             incoming_seq_num  = engine.incoming_seq_num + 1;
             fe_cache = CacheMessage m :: [];
-    } else
+        } |> with_transition_message GapDetected
+    else
     (* Message sequence number is OK -- lets process its data *)
     match m.full_msg_data with
     | Full_FIX_Admin_Msg adm_msg ->
@@ -298,10 +302,10 @@ let run_active_session ( m, engine : full_valid_fix_msg * fix_engine_state ) =
                 }
             | Full_Msg_Logon _data           -> engine
             | Full_Msg_Logoff _data          ->
-                let engine = logoff_and_shutdown ("Logoff message received during active session", engine) in
+                let engine = logoff_and_shutdown ("Logout message received during active session", engine) in
                 { engine with incoming_seq_num = m.full_msg_header.h_msg_seq_num 
                 ; fe_curr_mode = NoActiveSession
-                }
+                } |> with_transition_message LogoutComplete
             | Full_Msg_Reject _data          -> { engine with incoming_seq_num = m.full_msg_header.h_msg_seq_num }
             | Full_Msg_Business_Reject _data -> { engine with incoming_seq_num = m.full_msg_header.h_msg_seq_num }
             | Full_Msg_Resend_Request data  ->
@@ -317,7 +321,7 @@ let run_active_session ( m, engine : full_valid_fix_msg * fix_engine_state ) =
                         fe_history              = add_msg_to_history ( engine.fe_history, hearbeat_msg );
                         outgoing_seq_num        = engine.outgoing_seq_num + 1;
                         incoming_seq_num        = m.full_msg_header.h_msg_seq_num;
-                }
+                } |> with_transition_message ( TestRequestReceived data.test_req_id )
         end
     | Full_FIX_App_Msg app_msg          ->
         (* We're processing an application type of message. We just need
@@ -351,9 +355,10 @@ let run_active_session ( m, engine : full_valid_fix_msg * fix_engine_state ) =
 let run_wait_heartbeat ( msg, engine ) =
     match msg.full_msg_data with
     | Full_FIX_Admin_Msg ( Full_Msg_Heartbeat _d ) ->
-        let engine = {engine with fe_curr_mode = ActiveSession } in
+        let engine = {engine with fe_curr_mode = ActiveSession} 
+        |> with_transition_message TestRequestAcknowledged in
         run_active_session  (msg , engine)
-    | _ -> engine
+    | _ -> engine |> with_transition_message ( MessageIgnored "Waiting for Heartbeat message" )
 ;;
 
 (** We're in a GapDetected state. Sending out resend request and transitioning into Recovery.*)
@@ -366,6 +371,7 @@ let run_gap_detected ( engine : fix_engine_state ) =
         fe_history       = add_msg_to_history ( engine.fe_history, resend_msg );
         outgoing_seq_num = engine.outgoing_seq_num + 1;
     }
+    |> with_transition_message GapDetected
 ;;
 
 
@@ -498,9 +504,11 @@ let run_recovery ( m, engine : full_valid_fix_msg * fix_engine_state ) =
 (** We've sent out a Logout message and are now waiting for a confirmation of logout. *)
 let run_shutdown ( m, engine : full_valid_fix_msg * fix_engine_state ) =
     match m.full_msg_data with
-    | Full_FIX_Admin_Msg ( Full_Msg_Logoff _m )          -> { engine with fe_curr_mode = NoActiveSession; }
+    | Full_FIX_Admin_Msg ( Full_Msg_Logoff _m )          -> { engine with 
+        fe_curr_mode = NoActiveSession; 
+    } |> with_transition_message ( TerminateTransport "Clean logout" )
     | Full_FIX_Admin_Msg ( Full_Msg_Resend_Request m )  ->
     (* Since after initiating a Logoff, we can still process Resend request. *)
         initiate_Resend ( ShutdownInitiated, m, engine)
-    | _ -> engine
+    | _ -> engine |> with_transition_message ( MessageIgnored "Waiting for Logout message" )
 ;;

--- a/fix-engine/src/fix_engine_transitions.iml
+++ b/fix-engine/src/fix_engine_transitions.iml
@@ -26,7 +26,7 @@ open Fix_engine_utils;;
 
 (** In many abnormal cases we need to send out the Logout messages and
     transition to ShutdownInitiated state. *)
-let logoff_and_shutdown ( engine : fix_engine_state ) =
+let logoff_and_shutdown ( reason, engine : string * fix_engine_state ) =
     let logoff_msg = create_logoff_msg ( engine ) in
     { engine with
         fe_last_time_data_sent  = engine.fe_curr_time;
@@ -34,6 +34,7 @@ let logoff_and_shutdown ( engine : fix_engine_state ) =
         outgoing_fix_msg        = Some ( ValidMsg ( logoff_msg ));
         outgoing_seq_num        = engine.outgoing_seq_num + 1;
         fe_history              = add_msg_to_history ( engine.fe_history, logoff_msg );
+        transition_log          = Some (ShuttingDown reason)
     }
 ;;
 
@@ -105,22 +106,25 @@ let run_no_active_session ( m, engine : full_valid_fix_msg * fix_engine_state ) 
     match m.full_msg_data with
     | Full_FIX_Admin_Msg ( Full_Msg_Logon d ) ->
         begin
-            if ( m.full_msg_header.h_target_comp_id <> engine.fe_comp_id ) ||
+            if ( m.full_msg_header.h_target_comp_id <> engine.fe_comp_id ) then
+                { engine with transition_log = Some (LogonFailed "Invalid TargetCompID") }
+            else if
                ( m.full_msg_header.h_sender_comp_id <> engine.fe_target_comp_id )
                then
-                engine
+                { engine with transition_log = Some (LogonFailed "Invalid SenderCompID") }
             else if
               (* TODO: better timestamp comparison *)
               let sending_day, _ps = m.full_msg_header.h_sending_time |> T.to_span |> T.Span.to_d_ps in
               let current_day, _ps = engine.fe_curr_time |> T.to_span |> T.Span.to_d_ps in
               sending_day <> current_day
             then
-              logoff_and_shutdown engine
+              logoff_and_shutdown ("Invalid SendingTime in Logon message", engine)
             else if ( engine.fe_encrypt_method <> d.ln_encrypt_method &&
                 engine.fe_num_logons_sent >= engine.fe_max_num_logons_sent ) then {
                     engine with
                         fe_curr_mode = Error;
                         fe_curr_status = MaxNumLogonMsgsViolated;
+                        transition_log = Some (LogonFailed "Maximum number of logon attempts exceeded")
             } else
                 begin
                     let engine = match d.ln_reset_seq_num_flag with
@@ -142,16 +146,18 @@ let run_no_active_session ( m, engine : full_valid_fix_msg * fix_engine_state ) 
                             fe_num_logons_sent      = engine.fe_num_logons_sent + 1;
                         } in
                     if m.full_msg_header.h_msg_seq_num < (engine.incoming_seq_num + 1) then
-                        logoff_and_shutdown engine
+                        logoff_and_shutdown ("Invalid SequenceNumber in Logon message", engine)
                     else if msg_is_sequence_gap ( engine, m.full_msg_header )
                     then { engine with
                         incoming_seq_num  = engine.incoming_seq_num + 1;
                         fe_curr_mode      = GapDetected;
+                        transition_log    = Some (LogonSucceeded "Gap detected")
                     } else
                     { engine with
                         fe_curr_mode      = ActiveSession;
                         incoming_seq_num  = m.full_msg_header.h_msg_seq_num;
                         fe_history        = add_msg_to_history ( engine.fe_history, logon_msg );
+                        transition_log    = Some (LogonSucceeded "Session active")
                     }
                 end
         end
@@ -267,7 +273,7 @@ let run_active_session ( m, engine : full_valid_fix_msg * fix_engine_state ) =
     let possdup = match header.h_poss_dup_flag with Some true -> true | _ -> false in
     if is_duplicate && not possdup then
         (* Message is a duplicate, but no PossibleDuplicate flag -- we instantly logoff *)
-        logoff_and_shutdown engine
+        logoff_and_shutdown ("Duplicate message received without PossibleDuplicate flag", engine)
     else if is_duplicate then
         (* Message is a duplicate and passed all checks -- ignore it. *)
         engine
@@ -292,7 +298,7 @@ let run_active_session ( m, engine : full_valid_fix_msg * fix_engine_state ) =
                 }
             | Full_Msg_Logon _data           -> engine
             | Full_Msg_Logoff _data          ->
-                let engine = logoff_and_shutdown engine in
+                let engine = logoff_and_shutdown ("Logoff message received during active session", engine) in
                 { engine with incoming_seq_num = m.full_msg_header.h_msg_seq_num 
                 ; fe_curr_mode = NoActiveSession
                 }
@@ -460,7 +466,7 @@ let rec update_cache ( cache : cache_entry list ) (msg : cache_entry)  =
     Transition to CacheReplay when the cahce is complete. *)
 let run_recovery ( m, engine : full_valid_fix_msg * fix_engine_state ) =
     match m.full_msg_data with
-    | Full_FIX_Admin_Msg (Full_Msg_Logoff _m) -> logoff_and_shutdown ( engine )
+    | Full_FIX_Admin_Msg (Full_Msg_Logoff _m) -> logoff_and_shutdown ("Logoff message received during recovery", engine )
     | Full_FIX_Admin_Msg (Full_Msg_Resend_Request m) -> initiate_Resend ( Recovery, m, engine)
     | _ ->
     let msg = match m with

--- a/fix-engine/src/fix_engine_utils.iml
+++ b/fix-engine/src/fix_engine_utils.iml
@@ -30,6 +30,11 @@ let msg_is_sequence_gap ( engine, msg_header : fix_engine_state * fix_header ) =
     msg_header.h_msg_seq_num > engine.incoming_seq_num + 1
 ;;
 
+(* Add message to transition_log for external observability *)
+let with_transition_message ( message : transition_message ) ( engine : fix_engine_state) = 
+    { engine with transition_log = message :: engine.transition_log }
+;;
+
 (** get_gap_fill_msg -> out of all of the administrative messages, only the 'Reject' can be retransmitted.
     All application-level messages may be retransmitted - we should, in the future add logic to
     not retransmit stale orders, etc. *)
@@ -352,6 +357,8 @@ let validate_message_header ( engine, msg_header, msg_tag : fix_engine_state * f
             srej_msg_reject_reason = Some SendingTimeAccuracyProblem;
             } in
         let engine = session_reject ( reject , engine ) in
-        Some { engine with fe_curr_mode = ShuttingDown }
+        Some ({ engine with 
+            fe_curr_mode = ShuttingDown; 
+        } |> with_transition_message ( MissingField Full_Field_OrigSendingTime_Tag ) )
     else None
 ;;


### PR DESCRIPTION
- Exposes transition messages via the runtime, improving observability of internal engine state (e.g. FIX connection logon status).
- Initiates transport termination where appropriate (after clean `Logout`, under timeout conditions, after failed `CompID` Logon validations [as defined in the FIX Session Layer specification](https://www.fixtrading.org/standards/fix-session-layer-online/#when-to-terminate-a-fix-connection-by-terminating-the-transport-layer-connection-instead-of-sending-a-logout355)).
- Handles unclean shutdown, where initiated `Logout` message is ignored by the peer. Uses `HeartbeatInt * 2` as the threshold [as recommended in the FIX Session Layer specification](https://www.fixtrading.org/standards/fix-session-layer-online/#fix-connection-termination).