### PR TITLE
Update the MessageIgnored transition to expose SessionReject info

### DIFF
--- a/fix-engine/src-protocol-pp/fix_engine_json.iml
+++ b/fix-engine/src-protocol-pp/fix_engine_json.iml
@@ -42,6 +42,7 @@ let fix_engine_mode_to_string = function
 let message_ignore_reason_to_string = function
   | WaitingForHeartbeat -> "WaitingForHeartbeat"
   | WaitingForLogout -> "WaitingForLogout"
+  | Garbled -> "Garbled"
   | SessionReject reject_data -> "SessionReject - " ^
                                   (match reject_data.srej_msg_reject_reason with
                                    | Some reason -> Full_admin_enums_json.session_reject_reason_to_string reason ^ match(reject_data.srej_msg_field_tag) with

--- a/fix-engine/src-protocol-pp/fix_engine_json.iml
+++ b/fix-engine/src-protocol-pp/fix_engine_json.iml
@@ -42,8 +42,14 @@ let fix_engine_mode_to_string = function
 let message_ignore_reason_to_string = function
   | WaitingForHeartbeat -> "WaitingForHeartbeat"
   | WaitingForLogout -> "WaitingForLogout"
-  | SessionReject (Some reason) -> "SessionReject - " ^ Full_admin_enums_json.session_reject_reason_to_string reason
-  | SessionReject None -> "SessionReject - NoReason"
+  | SessionReject reject_data -> "SessionReject - " ^
+                                  (match reject_data.srej_msg_reject_reason with
+                                   | Some reason -> Full_admin_enums_json.session_reject_reason_to_string reason ^ match(reject_data.srej_msg_field_tag) with
+                                                                                                                  | Some (Full_Admin_Field_Tag t) -> " (Tag: " ^ full_admin_field_tag_to_string t ^ ")"
+                                                                                                                  | Some (Full_App_Field_Tag s) -> " (Tag: " ^ s ^ ")"                                   
+                                                                                                                  | None -> ""
+                                   | None -> "NoReason")
+
 
 let fix_engine_transition_message_to_string = function
     | ShuttingDown msg                                  -> "ShuttingDown: " ^ msg

--- a/fix-engine/src-protocol-pp/fix_engine_json.iml
+++ b/fix-engine/src-protocol-pp/fix_engine_json.iml
@@ -48,7 +48,7 @@ let message_ignore_reason_to_string = function
                                                                                                                   | Some (Full_Admin_Field_Tag t) -> " (Tag: " ^ full_admin_field_tag_to_string t ^ ")"
                                                                                                                   | Some (Full_App_Field_Tag s) -> " (Tag: " ^ s ^ ")"                                   
                                                                                                                   | None -> ""
-                                   | None -> "NoReason")
+                                   | None -> "NoReason") 
 
 
 let fix_engine_transition_message_to_string = function

--- a/fix-engine/src-protocol-pp/fix_engine_json.iml
+++ b/fix-engine/src-protocol-pp/fix_engine_json.iml
@@ -45,10 +45,10 @@ let message_ignore_reason_to_string = function
   | Garbled -> "Garbled"
   | SessionReject reject_data -> "SessionReject - " ^
                                   (match reject_data.srej_msg_reject_reason with
-                                   | Some reason -> Full_admin_enums_json.session_reject_reason_to_string reason ^ match(reject_data.srej_msg_field_tag) with
+                                   | Some reason -> Full_admin_enums_json.session_reject_reason_to_string reason ^ (match(reject_data.srej_msg_field_tag) with
                                                                                                                   | Some (Full_Admin_Field_Tag t) -> " (Tag: " ^ full_admin_field_tag_to_string t ^ ")"
                                                                                                                   | Some (Full_App_Field_Tag s) -> " (Tag: " ^ s ^ ")"                                   
-                                                                                                                  | None -> ""
+                                                                                                                  | None -> "")
                                    | None -> "NoReason") 
 
 

--- a/fix-engine/src-protocol-pp/fix_engine_json.iml
+++ b/fix-engine/src-protocol-pp/fix_engine_json.iml
@@ -38,6 +38,13 @@ let fix_engine_mode_to_string = function
     | WaitingForHeartbeat                               -> "WaitingForHeartbeat"
 ;;
 
+
+let message_ignore_reason_to_string = function
+  | WaitingForHeartbeat -> "WaitingForHeartbeat"
+  | WaitingForLogout -> "WaitingForLogout"
+  | SessionReject (Some reason) -> "SessionReject - " ^ Full_admin_enums_json.session_reject_reason_to_string reason
+  | SessionReject None -> "SessionReject - NoReason"
+
 let fix_engine_transition_message_to_string = function
     | ShuttingDown msg                                  -> "ShuttingDown: " ^ msg
     | LogonFailed msg                                   -> "LogonFailed: " ^ msg
@@ -52,7 +59,7 @@ let fix_engine_transition_message_to_string = function
     | TestRequestSent msg                               -> "TestRequestSent: " ^ msg
     | TestRequestTimeout                                -> "TestRequestTimeout"
     | TestRequestAcknowledged                           -> "TestRequestAcknowledged"
-    | MessageIgnored msg                                -> "MessageIgnored: " ^ msg
+    | MessageIgnored ignore_reason                      -> "MessageIgnored: " ^ message_ignore_reason_to_string ignore_reason
     | TerminateTransport msg                            -> "TerminateTransport: " ^ msg 
 
 let manual_int_data_to_json x : Yojson.Basic.t = match x with

--- a/fix-engine/src-protocol-pp/full_admin_messages_decoder.iml
+++ b/fix-engine/src-protocol-pp/full_admin_messages_decoder.iml
@@ -22,12 +22,12 @@ open Full_admin_messages
 open Full_message_tags_decoder
 module D = Decoders_yojson.Basic.Decode
 
-
 let or_raw_fix decode =
   let open D in
   one_of
-    [("value", (decode >|= fun x -> Ok x));
-     ("raw_fix", (string >|= fun s -> Error s));
+    [
+      ("value", decode >|= fun x -> Ok x);
+      ("raw_fix", string >|= fun s -> Error s);
     ]
 
 let full_msg_heartbeat_decoder : full_msg_heartbeat_data D.decoder =

--- a/fix-engine/src/fix_engine.iml
+++ b/fix-engine/src/fix_engine.iml
@@ -218,7 +218,9 @@ let proc_incoming_fix_msg ( m, engine : full_top_level_msg * fix_engine_state) =
             match engine.fe_curr_mode with
             | ActiveSession         -> let state' = session_reject ( data, engine ) in 
                                        { state' with fe_last_data_received = engine.fe_curr_time }
-            | _                     -> engine
+            | _                     -> 
+               engine
+                                      |> with_transition_message (MessageIgnored (SessionReject data.srej_msg_reject_reason))
         end
     | BusinessRejectedMsg data  ->
         begin

--- a/fix-engine/src/fix_engine.iml
+++ b/fix-engine/src/fix_engine.iml
@@ -213,6 +213,7 @@ let proc_incoming_int_msg ( x, engine : fix_engine_int_inc_msg * fix_engine_stat
 let proc_incoming_fix_msg ( m, engine : full_top_level_msg * fix_engine_state) = 
     match m with
     | Garbled                   -> engine   (* Garbled messages are simply ignored. Note the timestamp is not updated. *)
+                                  |> with_transition_message (MessageIgnored Garbled)
     | SessionRejectedMsg data   -> 
         begin
             match engine.fe_curr_mode with

--- a/fix-engine/src/fix_engine.iml
+++ b/fix-engine/src/fix_engine.iml
@@ -220,7 +220,7 @@ let proc_incoming_fix_msg ( m, engine : full_top_level_msg * fix_engine_state) =
                                        { state' with fe_last_data_received = engine.fe_curr_time }
             | _                     -> 
                engine
-                                      |> with_transition_message (MessageIgnored (SessionReject data.srej_msg_reject_reason))
+                                      |> with_transition_message (MessageIgnored (SessionReject data))
         end
     | BusinessRejectedMsg data  ->
         begin

--- a/fix-engine/src/fix_engine_state.iml
+++ b/fix-engine/src/fix_engine_state.iml
@@ -12,6 +12,7 @@
 open Datetime
 
 [@@@import "../src-protocol/full_admin_enums.iml"]
+
 [@@@import "../src-protocol/full_admin_tags.iml"]
 
 [@@@import "../src-protocol/full_messages.iml"]
@@ -85,6 +86,11 @@ type cache_entry =
   | CacheMessage of full_valid_fix_msg
   | CacheGap of int * int
 
+type message_ignore_reason =
+  | WaitingForHeartbeat
+  | WaitingForLogout
+  | SessionReject of Full_admin_enums.fix_session_reject_reason option
+
 type transition_message =
   | ShuttingDown of string
   | LogonFailed of string
@@ -99,7 +105,7 @@ type transition_message =
   | TestRequestSent of string
   | TestRequestAcknowledged
   | TestRequestTimeout
-  | MessageIgnored of string
+  | MessageIgnored of message_ignore_reason
   | TerminateTransport of string
 
 type fix_engine_state = {

--- a/fix-engine/src/fix_engine_state.iml
+++ b/fix-engine/src/fix_engine_state.iml
@@ -89,6 +89,7 @@ type cache_entry =
 type message_ignore_reason =
   | WaitingForHeartbeat
   | WaitingForLogout
+  | Garbled
   | SessionReject of Full_messages.session_rejected_msg_data
 
 type transition_message =

--- a/fix-engine/src/fix_engine_state.iml
+++ b/fix-engine/src/fix_engine_state.iml
@@ -89,7 +89,7 @@ type cache_entry =
 type message_ignore_reason =
   | WaitingForHeartbeat
   | WaitingForLogout
-  | SessionReject of Full_admin_enums.fix_session_reject_reason option
+  | SessionReject of Full_messages.session_rejected_msg_data
 
 type transition_message =
   | ShuttingDown of string

--- a/fix-engine/src/fix_engine_transitions.iml
+++ b/fix-engine/src/fix_engine_transitions.iml
@@ -358,7 +358,7 @@ let run_wait_heartbeat ( msg, engine ) =
         let engine = {engine with fe_curr_mode = ActiveSession} 
         |> with_transition_message TestRequestAcknowledged in
         run_active_session  (msg , engine)
-    | _ -> engine |> with_transition_message ( MessageIgnored "Waiting for Heartbeat message" )
+    | _ -> engine |> with_transition_message ( MessageIgnored WaitingForHeartbeat )
 ;;
 
 (** We're in a GapDetected state. Sending out resend request and transitioning into Recovery.*)
@@ -510,5 +510,5 @@ let run_shutdown ( m, engine : full_valid_fix_msg * fix_engine_state ) =
     | Full_FIX_Admin_Msg ( Full_Msg_Resend_Request m )  ->
     (* Since after initiating a Logoff, we can still process Resend request. *)
         initiate_Resend ( ShutdownInitiated, m, engine)
-    | _ -> engine |> with_transition_message ( MessageIgnored "Waiting for Logout message" )
+    | _ -> engine |> with_transition_message ( MessageIgnored WaitingForLogout )
 ;;


### PR DESCRIPTION
Closes #216 

With this change, we can now see log statements for messages which result in a session reject. For example, sending in 
`8=FIX.4.2|9=66|35=A|49=COMP|56=IMANDRA|34=1|52=202-4-1-0-10-20:34:29.980|98=0|108=30|10=042|` (notice the malformed date) results in: 
> FIX message ignored: SessionReject - IncorrectDataFormatForValue